### PR TITLE
Return instead of exit(-1) on invalid arguments

### DIFF
--- a/src/blas/level1/drotm.c
+++ b/src/blas/level1/drotm.c
@@ -5,7 +5,7 @@ void drotm(const uint64_t N, float64_t *X, const uint64_t incX, float64_t *Y, co
    const float64_t flag = *P;
    float64_t h11, h21, h12, h22, w, z;
 
-   if f64_eq(flag, SB_REAL64_NEGTWO) exit(-1);
+   if f64_eq(flag, SB_REAL64_NEGTWO) return;
    if (f64_eq(flag, SB_REAL64_NEGONE))
    {
       h11 = P[1]; h21 = P[2]; h12 = P[3]; h22 = P[4];

--- a/src/blas/level1/drotmg.c
+++ b/src/blas/level1/drotmg.c
@@ -15,14 +15,14 @@ void drotmg(float64_t *D1, float64_t *D2, float64_t *X1, const float64_t y1, flo
     {
         *P = SB_REAL64_NEGONE;
         *D1 = *D2 = *X1 = P[1] = P[2] = P[3] = P[4] = SB_REAL64_ZERO;
-        exit(-1);
+        return;
     }
 
     p2 = f64_mul(d2, y1);
     if (f64_eq(p2, SB_REAL64_ZERO))
     {
         *P = SB_REAL64_NEGTWO;
-        exit(-1);
+        return;
     }
 
     p1 = f64_mul(d1, x1);
@@ -47,7 +47,7 @@ void drotmg(float64_t *D1, float64_t *D2, float64_t *X1, const float64_t y1, flo
         {
             *P = SB_REAL64_NEGONE;
             *D1 = *D2 = *X1 = P[1] = P[2] = P[3] = P[4] = SB_REAL64_ZERO;
-            exit(-1);
+            return;
         }
         flag = SB_REAL64_ONE;
         h11 = f64_div(p1, p2);

--- a/src/blas/level1/dswap.c
+++ b/src/blas/level1/dswap.c
@@ -3,7 +3,7 @@
 void dswap(uint64_t N, float64_t *DX, uint64_t incX, float64_t *DY, uint64_t incY) {
     float64_t dtemp;
 
-    if (N == 0) exit(-1);
+    if (N == 0) return;
 
     uint64_t iX = 0;
     uint64_t iY = 0;

--- a/src/blas/level1/hrotm.c
+++ b/src/blas/level1/hrotm.c
@@ -5,7 +5,7 @@ void hrotm(const uint16_t N, float16_t *X, const uint16_t incX, float16_t *Y, co
    const float16_t flag = *P;
    float16_t h11, h21, h12, h22, w, z;
 
-   if (f16_eq(flag, SB_REAL16_NEGTWO)) exit(-1);
+   if (f16_eq(flag, SB_REAL16_NEGTWO)) return;
    if (f16_eq(flag, SB_REAL16_NEGONE))
    {
       h11 = P[1]; h21 = P[2]; h12 = P[3]; h22 = P[4];

--- a/src/blas/level1/hrotmg.c
+++ b/src/blas/level1/hrotmg.c
@@ -15,14 +15,14 @@ void hrotmg(float16_t *D1, float16_t *D2, float16_t *X1, const float16_t y1, flo
     {
         *P = SB_REAL16_NEGONE;
         *D1 = *D2 = *X1 = P[1] = P[2] = P[3] = P[4] = SB_REAL16_ZERO;
-        exit(-1);
+        return;
     }
 
     p2 = f16_mul(d2, y1);
     if (f16_eq(p2, SB_REAL16_ZERO))
     {
         *P = SB_REAL16_NEGTWO;
-        exit(-1);
+        return;
     }
 
     p1 = f16_mul(d1, x1);
@@ -47,7 +47,7 @@ void hrotmg(float16_t *D1, float16_t *D2, float16_t *X1, const float16_t y1, flo
         {
             *P = SB_REAL16_NEGONE;
             *D1 = *D2 = *X1 = P[1] = P[2] = P[3] = P[4] = SB_REAL16_ZERO;
-            exit(-1);
+            return;
         }
         flag = SB_REAL16_ONE;
         h11 = f16_div(p1, p2);

--- a/src/blas/level1/hswap.c
+++ b/src/blas/level1/hswap.c
@@ -3,7 +3,7 @@
 void hswap(uint64_t N, float16_t *HX, uint64_t incX, float16_t *HY, uint64_t incY) {
     float16_t htemp;
 
-    if (N == 0) exit(-1);
+    if (N == 0) return;
 
     uint64_t iX = 0;
     uint64_t iY = 0;

--- a/src/blas/level1/qswap.c
+++ b/src/blas/level1/qswap.c
@@ -3,7 +3,7 @@
 void qswap(uint64_t N, float128_t *QX, uint64_t incX, float128_t *QY, uint64_t incY) {
     float128_t qtemp;
 
-    if (N == 0) exit(-1);
+    if (N == 0) return;
 
     uint64_t iX = 0;
     uint64_t iY = 0;

--- a/src/blas/level1/srotm.c
+++ b/src/blas/level1/srotm.c
@@ -5,7 +5,7 @@ void srotm(const uint32_t N, float32_t *X, const uint32_t incX, float32_t *Y, co
    const float32_t flag = *P;
    float32_t h11, h21, h12, h22, w, z;
 
-   if f32_eq(flag, SB_REAL32_NEGTWO) exit(-1);
+   if f32_eq(flag, SB_REAL32_NEGTWO) return;
    if (f32_eq(flag, SB_REAL32_NEGONE))
    {
       h11 = P[1]; h21 = P[2]; h12 = P[3]; h22 = P[4];

--- a/src/blas/level1/srotmg.c
+++ b/src/blas/level1/srotmg.c
@@ -15,14 +15,14 @@ void srotmg(float32_t *D1, float32_t *D2, float32_t *X1, const float32_t y1, flo
     {
         *P = SB_REAL32_NEGONE;
         *D1 = *D2 = *X1 = P[1] = P[2] = P[3] = P[4] = SB_REAL32_ZERO;
-        exit(-1);
+        return;
     }
 
     p2 = f32_mul(d2, y1);
     if (f32_eq(p2, SB_REAL32_ZERO))
     {
         *P = SB_REAL32_NEGTWO;
-        exit(-1);
+        return;
     }
 
     p1 = f32_mul(d1, x1);
@@ -47,7 +47,7 @@ void srotmg(float32_t *D1, float32_t *D2, float32_t *X1, const float32_t y1, flo
         {
             *P = SB_REAL32_NEGONE;
             *D1 = *D2 = *X1 = P[1] = P[2] = P[3] = P[4] = SB_REAL32_ZERO;
-            exit(-1);
+            return;
         }
         flag = SB_REAL32_ONE;
         h11 = f32_div(p1, p2);

--- a/src/blas/level1/sswap.c
+++ b/src/blas/level1/sswap.c
@@ -3,7 +3,7 @@
 void sswap(uint64_t N, float32_t *SX, uint64_t incX, float32_t *SY, uint64_t incY) {
     float32_t stemp;
 
-    if (N == 0) exit(-1);
+    if (N == 0) return;
 
     uint64_t iX = 0;
     uint64_t iY = 0;

--- a/src/blas/level2/dgemv.c
+++ b/src/blas/level2/dgemv.c
@@ -5,12 +5,12 @@ void dgemv(const char Layout, const char Trans, const uint64_t M, const uint64_t
 
     if (Layout != 'C' && Layout != 'c' && Layout != 'R' && Layout != 'r') {
         // Invalid order parameter
-        exit(-1);
+        return;
     }
 
     if (Trans != 'N' && Trans != 'n' && Trans != 'T' && Trans != 't') {
         // Invalid trans parameter
-        exit(-1);
+        return;
     }
 
     if (Layout == 'C' || Layout == 'c') {

--- a/src/blas/level2/hgemv.c
+++ b/src/blas/level2/hgemv.c
@@ -5,12 +5,12 @@ void hgemv(const char Layout, const char Trans, const uint64_t M, const uint64_t
 
     if (Layout != 'C' && Layout != 'c' && Layout != 'R' && Layout != 'r') {
         // Invalid order parameter
-        exit(-1);
+        return;
     }
 
     if (Trans != 'N' && Trans != 'n' && Trans != 'T' && Trans != 't') {
         // Invalid trans parameter
-        exit(-1);
+        return;
     }
 
     if (Layout == 'C' || Layout == 'c') {

--- a/src/blas/level2/qgemv.c
+++ b/src/blas/level2/qgemv.c
@@ -5,12 +5,12 @@ void qgemv(const char Layout, const char Trans, const uint64_t M, const uint64_t
 
     if (Layout != 'C' && Layout != 'c' && Layout != 'R' && Layout != 'r') {
         // Invalid order parameter
-        exit(-1);
+        return;
     }
 
     if (Trans != 'N' && Trans != 'n' && Trans != 'T' && Trans != 't') {
         // Invalid trans parameter
-        exit(-1);
+        return;
     }
 
     if (Layout == 'C' || Layout == 'c') {

--- a/src/blas/level2/sgemv.c
+++ b/src/blas/level2/sgemv.c
@@ -5,12 +5,12 @@ void sgemv(const char Layout, const char Trans, const uint64_t M, const uint64_t
 
     if (Layout != 'C' && Layout != 'c' && Layout != 'R' && Layout != 'r') {
         // Invalid order parameter
-        exit(-1);
+        return;
     }
 
     if (Trans != 'N' && Trans != 'n' && Trans != 'T' && Trans != 't') {
         // Invalid trans parameter
-        exit(-1);
+        return;
     }
 
     if (Layout == 'C' || Layout == 'c') {

--- a/src/blas/level3/dgemm.c
+++ b/src/blas/level3/dgemm.c
@@ -5,12 +5,12 @@ void dgemm(const char transA, const char transB, const uint64_t M, const uint64_
 
     if (transA != 'N' && transA != 'n' && transA != 'T' && transA != 't') {
         // Invalid transA parameter
-        exit(-1);
+        return;
     }
 
     if (transB != 'N' && transB != 'n' && transB != 'T' && transB != 't') {
         // Invalid transB parameter
-        exit(-1);
+        return;
     }
 
     for (uint64_t i = 0; i < M; i++) {

--- a/src/blas/level3/hgemm.c
+++ b/src/blas/level3/hgemm.c
@@ -5,12 +5,12 @@ void hgemm(const char transA, const char transB, const uint64_t M, const uint64_
 
     if (transA != 'N' && transA != 'n' && transA != 'T' && transA != 't') {
         // Invalid transA parameter
-        exit(-1);
+        return;
     }
 
     if (transB != 'N' && transB != 'n' && transB != 'T' && transB != 't') {
         // Invalid transB parameter
-        exit(-1);
+        return;
     }
 
     for (uint64_t i = 0; i < M; i++) {

--- a/src/blas/level3/qgemm.c
+++ b/src/blas/level3/qgemm.c
@@ -5,12 +5,12 @@ void qgemm(const char transA, const char transB, const uint64_t M, const uint64_
 
     if (transA != 'N' && transA != 'n' && transA != 'T' && transA != 't') {
         // Invalid transA parameter
-        exit(-1);
+        return;
     }
 
     if (transB != 'N' && transB != 'n' && transB != 'T' && transB != 't') {
         // "Invalid transB parameter
-        exit(-1);
+        return;
     }
 
     float128_t qtemp;

--- a/src/blas/level3/sgemm.c
+++ b/src/blas/level3/sgemm.c
@@ -5,12 +5,12 @@ void sgemm(const char transA, const char transB, const uint64_t M, const uint64_
 
     if (transA != 'N' && transA != 'n' && transA != 'T' && transA != 't') {
         // Invalid transA parameter
-        exit(-1);
+        return;
     }
 
     if (transB != 'N' && transB != 'n' && transB != 'T' && transB != 't') {
         // Invalid transB parameter
-        exit(-1);
+        return;
     }
 
     for (uint64_t i = 0; i < M; i++) {

--- a/tests/blas/include/test.h
+++ b/tests/blas/include/test.h
@@ -50,6 +50,8 @@ MunitResult test_sswap_two(const MunitParameter params[],
                            void* user_data_or_fixture);
 MunitResult test_sswap_stride(const MunitParameter params[],
                               void* user_data_or_fixture);
+MunitResult test_sswap_zero(const MunitParameter params[],
+                            void* user_data_or_fixture);
 MunitResult test_isamax_0(const MunitParameter params[],
                           void* user_data_or_fixture);
 MunitResult test_isamax_12345(const MunitParameter params[],
@@ -225,6 +227,8 @@ MunitResult test_sgemv_stride(const MunitParameter params[],
                               void* user_data_or_fixture);
 MunitResult test_sgemv_incx(const MunitParameter params[],
                             void* user_data_or_fixture);
+MunitResult test_sgemv_badlayout(const MunitParameter params[],
+                                 void* user_data_or_fixture);
 
 MunitResult test_dgemv_0_row(const MunitParameter params[],
                              void* user_data_or_fixture);

--- a/tests/blas/level1/test_sgemv.c
+++ b/tests/blas/level1/test_sgemv.c
@@ -231,3 +231,26 @@ MunitResult test_sgemv_incx(const MunitParameter params[],
     free(A); free(SX); free(SY); free(RY);
     return MUNIT_OK;
 }
+
+//  Regression: an invalid Layout must return without modifying Y or killing
+//  the process (these routines previously called exit(-1) on bad arguments).
+MunitResult test_sgemv_badlayout(const MunitParameter params[],
+                                 void *user_data) {
+    const float32_t alpha = { SB_REAL32_ONE };
+    const float32_t beta = { SB_REAL32_ONE };
+    float32_t* A = svec((float[]){1.0f, 2.0f, 3.0f, 4.0f}, 4);
+    float32_t* X = svec((float[]){1.0f, 2.0f}, 2);
+    float32_t* Y = svec((float[]){5.0f, 6.0f}, 2);
+
+    //  'X' is not a valid Layout; the routine must return immediately.
+    sgemv('X', 'N', 2, 2, alpha, A, 2, X, 1, beta, Y, 1);
+
+    //  Y must be untouched.
+    float32_t* RY = svec((float[]){5.0f, 6.0f}, 2);
+    for (uint64_t i = 0; i < 2; i++) {
+        assert_ulong(Y[i].v, ==, RY[i].v);
+    }
+
+    free(A); free(X); free(Y); free(RY);
+    return MUNIT_OK;
+}

--- a/tests/blas/level1/test_sswap.c
+++ b/tests/blas/level1/test_sswap.c
@@ -47,3 +47,22 @@ MunitResult test_sswap_stride(const MunitParameter params[],
 
     return MUNIT_OK;
 }
+
+//  Regression: N == 0 must be a no-op (BLAS spec), not a process-killing exit.
+MunitResult test_sswap_zero(const MunitParameter params[],
+                            void* user_data_or_fixture) {
+    float32_t* SX = svec((float[]){1.0f, 2.0f}, 2);
+    float32_t* SY = svec((float[]){3.0f, 4.0f}, 2);
+
+    sswap(0, SX, 1, SY, 1);   // no-op: must not crash or modify the vectors
+
+    float32_t* RX = svec((float[]){1.0f, 2.0f}, 2);
+    float32_t* RY = svec((float[]){3.0f, 4.0f}, 2);
+    for (uint64_t i = 0; i < 2; i++) {
+        assert_ulong(SX[i].v, ==, RX[i].v);
+        assert_ulong(SY[i].v, ==, RY[i].v);
+    }
+
+    free(SX); free(SY); free(RX); free(RY);
+    return MUNIT_OK;
+}

--- a/tests/test_all.c
+++ b/tests/test_all.c
@@ -25,6 +25,7 @@ int main(int argc, char* argv[MUNIT_ARRAY_PARAM(argc + 1)]) {
             {"/test_sscal_stride", test_sscal_stride, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
             {"/test_sswap_two", test_sswap_two, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
             {"/test_sswap_stride", test_sswap_two, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
+            {"/test_sswap_zero", test_sswap_zero, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
             {"/test_isamax_0", test_isamax_0, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
             {"/test_isamax_12345", test_isamax_12345, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
             {"/test_isamax_stride", test_isamax_stride, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
@@ -114,6 +115,7 @@ int main(int argc, char* argv[MUNIT_ARRAY_PARAM(argc + 1)]) {
             {"/test_sgemv_12345", test_sgemv_12345, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
             {"/test_sgemv_stride", test_sgemv_stride, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
             {"/test_sgemv_incx", test_sgemv_incx, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
+            {"/test_sgemv_badlayout", test_sgemv_badlayout, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
 
             {"/test_dgemv_0_row", test_dgemv_0_row, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
             {"/test_dgemv_0_col", test_dgemv_0_col, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},


### PR DESCRIPTION
Library routines called `exit(-1)` on bad arguments — invalid transpose/layout chars in `*gemm`/`*gemv`, and `N==0` in `*swap` — **terminating the entire calling process**. For an embedding host like the Urbit runtime, a bad argument from any computation would take down the process with no chance to recover or log.

The host already validates arguments and raises its own errors (Vere bails the jet via `u3m_bail`), so the BLAS routines should simply **return** rather than kill the process. Per @sigilante: Vere is the only client that matters, so no error-callback machinery is needed — a plain `return` is the right fix.

## Change
- Replace every `exit(-1)` in `src/` with an early `return` (all affected routines are `void`). This restores the pre-1.1.0 "return on error" behavior, but as a clean no-op rather than a partial result.
- **`*swap` spec fix:** BLAS defines `N<=0` as a no-op, but swap called `exit(-1)` on `N==0` while every other Level-1 routine already treats it as a no-op.
- Covers `*gemm`, `*gemv`, `*swap` (built) and the `*rotm`/`*rotmg` routines (not yet built) for a uniform "no `exit()` in `src/`" invariant.

## Tests
- `test_sswap_zero`: `sswap(0, …)` is a no-op (no crash, vectors unchanged).
- `test_sgemv_badlayout`: an invalid Layout returns without modifying Y.

Under the old code both of these would have **terminated the test runner** via `exit(-1)` — which is exactly the behavior being removed. **134/134 pass.**

> Independent of #8 (correctness fixes); the two touch different lines and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)