### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  test:
+    name: Build and run the munit test suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # The SoftFloat submodule is declared with an SSH URL; fetch
+          # submodules manually below over HTTPS so no deploy key is needed.
+          submodules: false
+
+      - name: Fetch submodules over HTTPS
+        run: |
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
+          git submodule update --init --recursive
+
+      - name: Build SoftFloat
+        run: make -C SoftFloat/build/Linux-x86_64-GCC
+
+      - name: Build test suite
+        run: make tests
+
+      - name: Run tests
+        run: ./test_all


### PR DESCRIPTION
Adds a CI workflow that builds and runs the munit test suite on every push to `master` and every pull request.

Steps (ubuntu-latest):
1. Checkout, then fetch submodules over HTTPS (SoftFloat's submodule URL is SSH; the workflow rewrites it to HTTPS so no deploy key is needed).
2. Build SoftFloat (`make -C SoftFloat/build/Linux-x86_64-GCC`).
3. Build the suite (`make tests`) and run it (`./test_all`).

This guards the regression tests added in #8 and #9 against future breakage. Once merged, open PRs can rebase onto master to pick up CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)