### PR TITLE
Coverage: gemv/gemm transpose paths and leading-dimension padding (C4/C5)

### DIFF
--- a/tests/blas/include/test.h
+++ b/tests/blas/include/test.h
@@ -433,4 +433,12 @@ MunitResult test_sgemm_nan(const MunitParameter params[], void* u);
 MunitResult test_daxpy_nan(const MunitParameter params[], void* u);
 MunitResult test_haxpy_nan(const MunitParameter params[], void* u);
 
+//  Transpose & padding coverage (C4/C5)
+MunitResult test_sgemv_trans(const MunitParameter params[], void* u);
+MunitResult test_sgemv_padlda(const MunitParameter params[], void* u);
+MunitResult test_sgemm_transA(const MunitParameter params[], void* u);
+MunitResult test_sgemm_transB(const MunitParameter params[], void* u);
+MunitResult test_hgemm_ldb(const MunitParameter params[], void* u);
+MunitResult test_qgemm_ldb(const MunitParameter params[], void* u);
+
 #endif // TEST_H

--- a/tests/blas/level1/test_hgemm.c
+++ b/tests/blas/level1/test_hgemm.c
@@ -210,3 +210,16 @@ MunitResult test_hgemm_5x4x3(const MunitParameter params[],
 
     return MUNIT_OK;
 }
+//  ldb != ldc: B stored with a pad column (ldb=3), C dense (ldc=2). half.
+//  A=[[1,2],[3,4]], B=[[5,6],[7,8]] -> C=[[19,22],[43,50]].
+MunitResult test_hgemm_ldb(const MunitParameter params[], void *user_data) {
+    const float16_t alpha = { SB_REAL16_ONE }, beta = { SB_REAL16_ZERO };
+    float16_t* A = hvec((uint16_t[]){0x3c00,0x4000,0x4200,0x4400}, 4);
+    float16_t* B = hvec((uint16_t[]){0x4500,0x4600,0x0, 0x4700,0x4800,0x0}, 6);
+    float16_t* C = hvec((uint16_t[]){0x0,0x0,0x0,0x0}, 4);
+    hgemm('N','N', 2,2,2, alpha, A, 2, B, 3, beta, C, 2, 'n');
+    float16_t* R = hvec((uint16_t[]){0x4cc0,0x4d80,0x5160,0x5240}, 4);  // 19,22,43,50
+    for (uint64_t i = 0; i < 4; i++) assert_ushort(C[i].v, ==, R[i].v);
+    free(A); free(B); free(C); free(R);
+    return MUNIT_OK;
+}

--- a/tests/blas/level1/test_qgemm.c
+++ b/tests/blas/level1/test_qgemm.c
@@ -323,3 +323,27 @@ MunitResult test_qgemm_5x4x3(const MunitParameter params[],
 
     return MUNIT_OK;
 }
+
+//  ldb != ldc: B stored with a pad column (ldb=3), C dense (ldc=2). quad.
+//  A=[[1,2],[3,4]], B=[[5,6],[7,8]] -> C=[[19,22],[43,50]].
+MunitResult test_qgemm_ldb(const MunitParameter params[], void *user_data) {
+    const float128_t alpha = { SB_REAL128L_ONE, SB_REAL128U_ONE };
+    const float128_t beta  = { SB_REAL128L_ZERO, SB_REAL128U_ZERO };
+    float128_t* A = qvec((float128_pair_t[]){
+        {.hi=0x3fff000000000000,.lo=0},{.hi=0x4000000000000000,.lo=0},
+        {.hi=0x4000800000000000,.lo=0},{.hi=0x4001000000000000,.lo=0}}, 4);
+    float128_t* B = qvec((float128_pair_t[]){
+        {.hi=0x4001400000000000,.lo=0},{.hi=0x4001800000000000,.lo=0},{.hi=0,.lo=0},
+        {.hi=0x4001c00000000000,.lo=0},{.hi=0x4002000000000000,.lo=0},{.hi=0,.lo=0}}, 6);
+    float128_t* C = qvec((float128_pair_t[]){{0,0},{0,0},{0,0},{0,0}}, 4);
+    qgemm('N','N', 2,2,2, alpha, A, 2, B, 3, beta, C, 2, 'n');
+    float128_t* R = qvec((float128_pair_t[]){
+        {.hi=0x4003300000000000,.lo=0},{.hi=0x4003600000000000,.lo=0},   // 19,22
+        {.hi=0x4004580000000000,.lo=0},{.hi=0x4004900000000000,.lo=0}}, 4); // 43,50
+    for (uint64_t i = 0; i < 4; i++) {
+        assert_ullong(C[i].v[0], ==, R[i].v[0]);
+        assert_ullong(C[i].v[1], ==, R[i].v[1]);
+    }
+    free(A); free(B); free(C); free(R);
+    return MUNIT_OK;
+}

--- a/tests/blas/level1/test_sgemm.c
+++ b/tests/blas/level1/test_sgemm.c
@@ -248,3 +248,32 @@ MunitResult test_sgemm_ldb(const MunitParameter params[],
     free(A); free(B); free(C); free(R);
     return MUNIT_OK;
 }
+
+//  Mixed transpose A^T * B (transA='T', transB='N'). A stored [[1,3],[2,4]] so
+//  A^T=[[1,2],[3,4]]; B=[[5,6],[7,8]] -> C=[[19,22],[43,50]]. Only 'T','T' and
+//  'N','N' were covered before.
+MunitResult test_sgemm_transA(const MunitParameter params[], void *user_data) {
+    const float32_t alpha = { SB_REAL32_ONE }, beta = { SB_REAL32_ZERO };
+    float32_t* A = svec((float[]){1.0f,3.0f,2.0f,4.0f}, 4);
+    float32_t* B = svec((float[]){5.0f,6.0f,7.0f,8.0f}, 4);
+    float32_t* C = svec((float[]){0.0f,0.0f,0.0f,0.0f}, 4);
+    sgemm('T', 'N', 2, 2, 2, alpha, A, 2, B, 2, beta, C, 2, 'n');
+    float32_t* R = svec((float[]){19.0f,22.0f,43.0f,50.0f}, 4);
+    for (uint64_t i = 0; i < 4; i++) assert_ulong(C[i].v, ==, R[i].v);
+    free(A); free(B); free(C); free(R);
+    return MUNIT_OK;
+}
+
+//  Mixed transpose A * B^T (transA='N', transB='T'). A=[[1,2],[3,4]]; B stored
+//  [[5,7],[6,8]] so B^T=[[5,6],[7,8]] -> C=[[19,22],[43,50]].
+MunitResult test_sgemm_transB(const MunitParameter params[], void *user_data) {
+    const float32_t alpha = { SB_REAL32_ONE }, beta = { SB_REAL32_ZERO };
+    float32_t* A = svec((float[]){1.0f,2.0f,3.0f,4.0f}, 4);
+    float32_t* B = svec((float[]){5.0f,7.0f,6.0f,8.0f}, 4);
+    float32_t* C = svec((float[]){0.0f,0.0f,0.0f,0.0f}, 4);
+    sgemm('N', 'T', 2, 2, 2, alpha, A, 2, B, 2, beta, C, 2, 'n');
+    float32_t* R = svec((float[]){19.0f,22.0f,43.0f,50.0f}, 4);
+    for (uint64_t i = 0; i < 4; i++) assert_ulong(C[i].v, ==, R[i].v);
+    free(A); free(B); free(C); free(R);
+    return MUNIT_OK;
+}

--- a/tests/blas/level1/test_sgemv.c
+++ b/tests/blas/level1/test_sgemv.c
@@ -254,3 +254,32 @@ MunitResult test_sgemv_badlayout(const MunitParameter params[],
     free(A); free(X); free(Y); free(RY);
     return MUNIT_OK;
 }
+
+//  Transpose path (Trans='T'): y = A^T x. A is 2x3 row-major [[1,2,3],[4,5,6]],
+//  x=[1,1] (len M=2), so y = [1+4, 2+5, 3+6] = [5,7,9] (len N=3). No gemv test
+//  exercised the transpose branch before.
+MunitResult test_sgemv_trans(const MunitParameter params[], void *user_data) {
+    const float32_t alpha = { SB_REAL32_ONE }, beta = { SB_REAL32_ZERO };
+    float32_t* A = svec((float[]){1.0f,2.0f,3.0f, 4.0f,5.0f,6.0f}, 6);
+    float32_t* X = svec((float[]){1.0f, 1.0f}, 2);
+    float32_t* Y = svec((float[]){0.0f, 0.0f, 0.0f}, 3);
+    sgemv('R', 'T', 2, 3, alpha, A, 3, X, 1, beta, Y, 1, 'n');
+    float32_t* RY = svec((float[]){5.0f, 7.0f, 9.0f}, 3);
+    for (uint64_t i = 0; i < 3; i++) assert_ulong(Y[i].v, ==, RY[i].v);
+    free(A); free(X); free(Y); free(RY);
+    return MUNIT_OK;
+}
+
+//  Padded leading dimension: A is logically 2x2 [[1,2],[3,4]] but stored with
+//  lda=3 (a trailing pad column). y = A*[1,1] = [3,7]; the pad must be skipped.
+MunitResult test_sgemv_padlda(const MunitParameter params[], void *user_data) {
+    const float32_t alpha = { SB_REAL32_ONE }, beta = { SB_REAL32_ZERO };
+    float32_t* A = svec((float[]){1.0f,2.0f,99.0f, 3.0f,4.0f,99.0f}, 6);
+    float32_t* X = svec((float[]){1.0f, 1.0f}, 2);
+    float32_t* Y = svec((float[]){0.0f, 0.0f}, 2);
+    sgemv('R', 'N', 2, 2, alpha, A, 3, X, 1, beta, Y, 1, 'n');
+    float32_t* RY = svec((float[]){3.0f, 7.0f}, 2);
+    for (uint64_t i = 0; i < 2; i++) assert_ulong(Y[i].v, ==, RY[i].v);
+    free(A); free(X); free(Y); free(RY);
+    return MUNIT_OK;
+}

--- a/tests/test_all.c
+++ b/tests/test_all.c
@@ -159,6 +159,12 @@ int main(int argc, char* argv[MUNIT_ARRAY_PARAM(argc + 1)]) {
             {"/test_sgemm_0_col", test_sgemm_0_col, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
             {"/test_sgemm_3x2x1_0", test_sgemm_3x2x1_0, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
             {"/test_sgemm_5x4x3", test_sgemm_5x4x3, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
+            {"/test_sgemv_trans", test_sgemv_trans, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
+            {"/test_sgemv_padlda", test_sgemv_padlda, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
+            {"/test_sgemm_transA", test_sgemm_transA, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
+            {"/test_sgemm_transB", test_sgemm_transB, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
+            {"/test_hgemm_ldb", test_hgemm_ldb, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
+            {"/test_qgemm_ldb", test_qgemm_ldb, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
             {"/test_sgemm_ldb", test_sgemm_ldb, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
 
             {"/test_dgemm_0_row", test_dgemm_0_row, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},


### PR DESCRIPTION
Two untested behavior classes, now covered. Test-only; everything passes (the code was already correct).

**C4 — transpose paths.** Only `'N','N'` and `'T','T'` gemm were exercised, and every gemv test used `Trans='N'`:
- `test_sgemv_trans` — `y = Aᵀx` (the gemv transpose branch)
- `test_sgemm_transA` / `test_sgemm_transB` — the mixed `'T','N'` and `'N','T'` gemm combos

**C5 — leading-dimension padding.** Only `s`/`d` gemm had an `ldb≠ldc` test:
- `test_sgemv_padlda` — gemv with `lda > N` (a pad column to skip)
- `test_hgemm_ldb` / `test_qgemm_ldb` — `ldb≠ldc` for half and quad gemm

**157/157.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)