### PR TITLE
Finish and build the complex Level-1 routines (C8 part 1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,12 @@ BLAS_SRCS = \
   $(BLAS_SRC_DIR_L1)/idamax.c \
   $(BLAS_SRC_DIR_L1)/ihamax.c \
   $(BLAS_SRC_DIR_L1)/iqamax.c \
+  $(BLAS_SRC_DIR_L1)/scasum.c \
+  $(BLAS_SRC_DIR_L1)/caxpy.c \
+  $(BLAS_SRC_DIR_L1)/ccopy.c \
+  $(BLAS_SRC_DIR_L1)/cdotc.c \
+  $(BLAS_SRC_DIR_L1)/scnrm2.c \
+  $(BLAS_SRC_DIR_L1)/csrot.c \
   $(BLAS_SRC_DIR_L2)/sgemv.c \
   $(BLAS_SRC_DIR_L2)/dgemv.c \
   $(BLAS_SRC_DIR_L2)/hgemv.c \

--- a/src/blas/level1/caxpy.c
+++ b/src/blas/level1/caxpy.c
@@ -7,7 +7,7 @@ void caxpy(uint64_t N, complex32_t CA, complex32_t *CX, int64_t incX, complex32_
       if (incX < 0) iX = (-N + 1) * incX;
       if (incY < 0) iY = (-N + 1) * incY;
       for (uint64_t i = 0; i < N; i++) {
-            CY[iY] = c32_add(CY[iY], c32_mul(CA, CX[iX]));
+            CY[iY] = nan_unify_c(c32_add(CY[iY], c32_mul(CA, CX[iX])));
             iX += incX;
             iY += incY;
       }

--- a/src/blas/level1/ccopy.c
+++ b/src/blas/level1/ccopy.c
@@ -7,8 +7,8 @@ void ccopy(uint64_t N, const complex32_t *CX, int64_t incX, complex32_t *CY, int
     if (incX < 0) ix = (-N + 1) * incX;
     if (incY < 0) iy = (-N + 1) * incY;
     for (uint64_t i = 0; i < N; i++) {
-        CY[iY] = CX[iX];
-        iX += incX;
-        iY += incY;
+        CY[iy] = nan_unify_c(CX[ix]);
+        ix += incX;
+        iy += incY;
     }
 }

--- a/src/blas/level1/cdotc.c
+++ b/src/blas/level1/cdotc.c
@@ -14,5 +14,5 @@ complex32_t cdotc(uint64_t N, const complex32_t *CX, int64_t incX, const complex
         iy += incY;
     }
 
-    return cdotc;
+    return nan_unify_c(cdotc);
 }

--- a/src/blas/level1/csrot.c
+++ b/src/blas/level1/csrot.c
@@ -9,8 +9,8 @@ void csrot(const uint64_t N, complex32_t *CX, const int64_t incX, complex32_t *C
     if (incY < 0) iy = (-N + 1) * incY;
     for (uint64_t i = 0; i < N; i++) {
         temp = c32_add(c32_mul(c, CX[ix]), c32_mul(s, CY[iy]));
-        CY[iy] = c32_sub(c32_mul(c, CY[iy]), c32_mul(s, CX[ix]));
-        CX[ix] = temp;
+        CY[iy] = nan_unify_c(c32_sub(c32_mul(c, CY[iy]), c32_mul(s, CX[ix])));
+        CX[ix] = nan_unify_c(temp);
         ix += incX;
         iy += incY;
     }

--- a/src/blas/level1/scasum.c
+++ b/src/blas/level1/scasum.c
@@ -1,8 +1,17 @@
 #include "softblas.h"
 
-float32_t scasum(uint64_t N, const complex32_t *CX, uint64_t incX, const uint_fast8_t rndMode) {
+//  Sum of |Re| + |Im| over a complex vector (the BLAS SCASUM convention).
+float32_t scasum(uint64_t N, const complex32_t *CX, int64_t incX, const uint_fast8_t rndMode) {
     _set_rounding(rndMode);
-      float32_t stemp = SB_FLOAT32_ZERO;
+    float32_t stemp = { SB_REAL32_ZERO };
+
+    if (incX < 1) {
+        return nan_unify_s(stemp);
+    }
+    for (uint64_t i = 0; i < N; i++) {
+        complex32_t z = CX[i * incX];
+        stemp = f32_add(stemp, f32_add(f32_abs(z.real), f32_abs(z.imag)));
+    }
 
     return nan_unify_s(stemp);
 }

--- a/src/blas/level1/scnrm2.c
+++ b/src/blas/level1/scnrm2.c
@@ -1,29 +1,35 @@
 #include "softblas.h"
 
+//  Euclidean norm of a complex vector: sqrt( sum |z_i|^2 ), computed as a
+//  scaled sum of squares over the 2N real components (Re and Im) to avoid
+//  overflow/underflow.
 float32_t scnrm2(uint64_t N, const complex32_t *CX, uint64_t incX, const uint_fast8_t rndMode) {
     _set_rounding(rndMode);
-      float32_t norm, scale, ssq, temp;
-      
-      if (N < 1 || incX < 1) {
-            norm = SB_REAL32_ZERO;
-      } else {
-            scale = SB_REAL32_ZERO;
-            ssq = SB_REAL32_ONE;
+    const float32_t ZERO = { SB_REAL32_ZERO };
 
-        for (uint64_t ix = 0; ix < 1 + (N - 1) * incX; ix += incX) {
-            if (f32_ne(X[ix], (complex32_t){ SB_REAL32_ZERO })) {
-                absXI = f32_abs(X[ix]);
+    if (N < 1 || incX < 1) {
+        return ZERO;
+    }
+
+    float32_t scale = { SB_REAL32_ZERO };
+    float32_t ssq   = { SB_REAL32_ONE };
+
+    for (uint64_t k = 0, ix = 0; k < N; k++, ix += incX) {
+        float32_t parts[2] = { CX[ix].real, CX[ix].imag };
+        for (int p = 0; p < 2; p++) {
+            if (f32_ne(parts[p], ZERO)) {
+                float32_t absXI = f32_abs(parts[p]);
                 if (f32_lt(scale, absXI)) {
-                    ssq = f32_add((complex32_t){ SB_REAL32_ONE }, f32_mul(ssq, f32_div(f32_mul(scale, scale), f32_mul(absXI, absXI))));
+                    float32_t r = f32_div(scale, absXI);
+                    ssq = f32_add((float32_t){ SB_REAL32_ONE }, f32_mul(ssq, f32_mul(r, r)));
                     scale = absXI;
                 } else {
-                    ssq = f32_add(ssq, f32_div(f32_mul(absXI, absXI), f32_mul(scale, scale)));
+                    float32_t r = f32_div(absXI, scale);
+                    ssq = f32_add(ssq, f32_mul(r, r));
                 }
             }
         }
-
-        norm = f32_mul(scale, f32_sqrt(ssq));
-
-        return norm;
     }
+
+    return nan_unify_s(f32_mul(scale, f32_sqrt(ssq)));
 }

--- a/tests/blas/include/test.h
+++ b/tests/blas/include/test.h
@@ -103,6 +103,18 @@ static inline float128_t* qvec(float128_pair_t pairs[], uint64_t size) {
     return result;
 }
 
+//  Build an array of complex32_t from interleaved (re, im) float literals;
+//  size is the number of complex elements.
+static inline complex32_t* cvec(float vals[], uint64_t size) {
+    complex32_t* result = malloc(size * sizeof(complex32_t));
+    if (result == NULL) abort();
+    for (uint64_t i = 0; i < size; i++) {
+        result[i].real.v = *(uint32_t*)&vals[2*i];
+        result[i].imag.v = *(uint32_t*)&vals[2*i+1];
+    }
+    return result;
+}
+
 //  Test function prototypes for BLAS Level 1
 MunitResult test_sasum_0(const MunitParameter params[],
                          void* user_data_or_fixture);
@@ -440,5 +452,13 @@ MunitResult test_sgemm_transA(const MunitParameter params[], void* u);
 MunitResult test_sgemm_transB(const MunitParameter params[], void* u);
 MunitResult test_hgemm_ldb(const MunitParameter params[], void* u);
 MunitResult test_qgemm_ldb(const MunitParameter params[], void* u);
+
+//  Complex Level-1 (test_complex.c)
+MunitResult test_caxpy_basic(const MunitParameter params[], void* u);
+MunitResult test_ccopy_basic(const MunitParameter params[], void* u);
+MunitResult test_cdotc_conj(const MunitParameter params[], void* u);
+MunitResult test_scasum_basic(const MunitParameter params[], void* u);
+MunitResult test_scnrm2_basic(const MunitParameter params[], void* u);
+MunitResult test_csrot_basic(const MunitParameter params[], void* u);
 
 #endif // TEST_H

--- a/tests/blas/level1/test_complex.c
+++ b/tests/blas/level1/test_complex.c
@@ -1,0 +1,57 @@
+#include "test.h"
+
+//  Complex (single-precision) Level-1 routines.
+
+MunitResult test_caxpy_basic(const MunitParameter params[], void* u) {
+    const complex32_t CA = {{ 0x3f800000 }, { 0x00000000 }};   // 1 + 0i
+    complex32_t* CX = cvec((float[]){1.0f, 2.0f}, 1);          // 1 + 2i
+    complex32_t* CY = cvec((float[]){3.0f, 4.0f}, 1);          // 3 + 4i
+    caxpy(1, CA, CX, 1, CY, 1, 'n');
+    assert_ulong(CY[0].real.v, ==, 0x40800000u);              // 4
+    assert_ulong(CY[0].imag.v, ==, 0x40c00000u);              // 6i
+    free(CX); free(CY);
+    return MUNIT_OK;
+}
+MunitResult test_ccopy_basic(const MunitParameter params[], void* u) {
+    complex32_t* CX = cvec((float[]){1.0f, 2.0f}, 1);
+    complex32_t* CY = cvec((float[]){0.0f, 0.0f}, 1);
+    ccopy(1, CX, 1, CY, 1, 'n');
+    assert_ulong(CY[0].real.v, ==, 0x3f800000u);              // 1
+    assert_ulong(CY[0].imag.v, ==, 0x40000000u);              // 2i
+    free(CX); free(CY);
+    return MUNIT_OK;
+}
+MunitResult test_cdotc_conj(const MunitParameter params[], void* u) {
+    complex32_t* CX = cvec((float[]){1.0f, 2.0f}, 1);          // 1 + 2i
+    complex32_t* CY = cvec((float[]){3.0f, 4.0f}, 1);          // 3 + 4i
+    complex32_t r = cdotc(1, CX, 1, CY, 1, 'n');              // conj(x)*y = 11 - 2i
+    assert_ulong(r.real.v, ==, 0x41300000u);                  // 11
+    assert_ulong(r.imag.v, ==, 0xc0000000u);                  // -2i
+    free(CX); free(CY);
+    return MUNIT_OK;
+}
+MunitResult test_scasum_basic(const MunitParameter params[], void* u) {
+    complex32_t* CX = cvec((float[]){1.0f, -2.0f, -3.0f, 4.0f}, 2);  // |1|+|2|+|3|+|4|
+    float32_t r = scasum(2, CX, 1, 'n');
+    assert_ulong(r.v, ==, 0x41200000u);                      // 10
+    free(CX);
+    return MUNIT_OK;
+}
+MunitResult test_scnrm2_basic(const MunitParameter params[], void* u) {
+    complex32_t* CX = cvec((float[]){3.0f, 4.0f}, 1);         // |3 + 4i| = 5
+    float32_t r = scnrm2(1, CX, 1, 'n');
+    assert_ulong(r.v, ==, 0x40a00000u);                      // 5
+    free(CX);
+    return MUNIT_OK;
+}
+MunitResult test_csrot_basic(const MunitParameter params[], void* u) {
+    complex32_t* CX = cvec((float[]){1.0f, 0.0f}, 1);
+    complex32_t* CY = cvec((float[]){2.0f, 0.0f}, 1);
+    const complex32_t c = {{ 0x00000000 }, { 0x00000000 }};  // 0
+    const complex32_t s = {{ 0x3f800000 }, { 0x00000000 }};  // 1
+    csrot(1, CX, 1, CY, 1, c, s, 'n');                       // 90-degree-like swap
+    assert_ulong(CX[0].real.v, ==, 0x40000000u);             // 2
+    assert_ulong(CY[0].real.v, ==, 0xbf800000u);             // -1
+    free(CX); free(CY);
+    return MUNIT_OK;
+}

--- a/tests/test_all.c
+++ b/tests/test_all.c
@@ -131,6 +131,13 @@ int main(int argc, char* argv[MUNIT_ARRAY_PARAM(argc + 1)]) {
             {"/test_iqamax_12345", test_iqamax_12345, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
             {"/test_iqamax_stride", test_iqamax_stride, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
             {"/test_iqamax_13542", test_iqamax_13542, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
+
+            {"/test_caxpy_basic", test_caxpy_basic, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
+            {"/test_ccopy_basic", test_ccopy_basic, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
+            {"/test_cdotc_conj", test_cdotc_conj, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
+            {"/test_scasum_basic", test_scasum_basic, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
+            {"/test_scnrm2_basic", test_scnrm2_basic, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
+            {"/test_csrot_basic", test_csrot_basic, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
             
             {"/test_sgemv_0_row", test_sgemv_0_row, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
             {"/test_sgemv_0_col", test_sgemv_0_col, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},


### PR DESCRIPTION
The complex routines the README lists as Implemented for `c` were broken or stubs and weren't in the build. Now implemented, built, and tested.

- **`scasum`** — was a stub (`return 0` + undefined `SB_FLOAT32_ZERO`). Now sum of `|Re|+|Im|`.
- **`scnrm2`** — was broken (referenced `X`, applied `f32` ops to `complex32_t`). Now a scaled sum of squares over the 2N real components.
- **`ccopy`** — declared `ix/iy` but used `iX/iY` (didn't compile). Fixed.
- **`caxpy` / `cdotc` / `csrot`** — compiled but weren't built or tested.

All six canonicalize their NaN output (`nan_unify_c`/`nan_unify_s`), consistent with the real routines, and are added to the Makefile. New `cvec()` helper + `test_complex.c` cover each with hand-computed values (caxpy `4+6i`, cdotc `11-2i`, scasum `10`, scnrm2 `5`, ccopy, csrot swap).

**157/157.** The README's `c` "Implemented" claims are now honest.

Remaining C8: the real rotation family (`srot/drot/hrot`, `rotg/rotm/rotmg`) and `sdsdot/hsdot` are still broken/unbuilt — they need Givens-rotation work and are a separate effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)