### PR TITLE
Fix transposed-matrix comments in gemv tests (closes #5)

### DIFF
--- a/tests/blas/level1/test_dgemv.c
+++ b/tests/blas/level1/test_dgemv.c
@@ -56,8 +56,8 @@ MunitResult test_dgemv_0_col(const MunitParameter params[],
     const float64_t beta = { SB_REAL64_ZERO };  // Dcalar beta
 
     // 2x2 matrix A (column-major order)
-    //   [1.0 3.0]
-    //   [2.0 4.0]
+    //   [1.0 2.0]
+    //   [3.0 4.0]
     const uint64_t M = 2;     // Number of rows in A
     const uint64_t N = 2;     // Number of columns in A
     float64_t* A = dvec((double[]){1.0, 3.0, 2.0, 4.0}, 4);

--- a/tests/blas/level1/test_hgemv.c
+++ b/tests/blas/level1/test_hgemv.c
@@ -8,8 +8,8 @@ MunitResult test_hgemv_0_row(const MunitParameter params[],
     const float16_t beta = { SB_REAL16_ZERO };  // Hcalar beta
 
     // 2x2 matrix A (row-major order)
-    //   [1.0 3.0]
-    //   [2.0 4.0]
+    //   [1.0 2.0]
+    //   [3.0 4.0]
     const uint64_t M = 2;     // Number of rows in A
     const uint64_t N = 2;     // Number of columns in A
     float16_t* A = hvec((uint16_t[]){0x3c00 , 0x4000 , 0x4200 , 0x4400 }, 4);
@@ -56,8 +56,8 @@ MunitResult test_hgemv_0_col(const MunitParameter params[],
     const float16_t beta = { SB_REAL16_ZERO };  // Hcalar beta
 
     // 2x2 matrix A (column-major order)
-    //   [1.0 3.0]
-    //   [2.0 4.0]
+    //   [1.0 2.0]
+    //   [3.0 4.0]
     const uint64_t M = 2;     // Number of rows in A
     const uint64_t N = 2;     // Number of columns in A
     float16_t* A = hvec((uint16_t[]){0x3c00 , 0x4200 , 0x4000 , 0x4400 }, 4);

--- a/tests/blas/level1/test_sgemv.c
+++ b/tests/blas/level1/test_sgemv.c
@@ -8,8 +8,8 @@ MunitResult test_sgemv_0_row(const MunitParameter params[],
     const float32_t beta = { SB_REAL32_ZERO };  // Scalar beta
 
     // 2x2 matrix A (row-major order)
-    //   [1.0 3.0]
-    //   [2.0 4.0]
+    //   [1.0 2.0]
+    //   [3.0 4.0]
     const uint64_t M = 2;     // Number of rows in A
     const uint64_t N = 2;     // Number of columns in A
     float32_t* A = svec((float[]){1.0f, 2.0f, 3.0f, 4.0f}, 4);
@@ -56,8 +56,8 @@ MunitResult test_sgemv_0_col(const MunitParameter params[],
     const float32_t beta = { SB_REAL32_ZERO };  // Scalar beta
 
     // 2x2 matrix A (column-major order)
-    //   [1.0 3.0]
-    //   [2.0 4.0]
+    //   [1.0 2.0]
+    //   [3.0 4.0]
     const uint64_t M = 2;     // Number of rows in A
     const uint64_t N = 2;     // Number of columns in A
     float32_t* A = svec((float[]){1.0f, 3.0f, 2.0f, 4.0f}, 4);


### PR DESCRIPTION
The `0_row`/`0_col` gemv tests commented the matrix as its transpose — `[[1,3],[2,4]]` for a matrix that is logically `[[1,2],[3,4]]`. The code was correct; only the comments were wrong. Fixed in `test_sgemv.c` (the issue), plus the same mistake found in `test_dgemv.c` and `test_hgemv.c`.

Closes #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)