### PR TITLE
Refactor rotmg to remove goto/labels

### DIFF
--- a/src/blas/level1/drotmg.c
+++ b/src/blas/level1/drotmg.c
@@ -42,29 +42,31 @@ void drotmg(float64_t *D1, float64_t *D2, float64_t *X1, const float64_t y1, flo
                 flag = NEGONE;
                 d1 = ZERO; d2 = ZERO; x1 = ZERO;
                 h11 = ZERO; h21 = ZERO; h12 = ZERO; h22 = ZERO;
-                goto store;
+            } else {
+                flag = ZERO;
+                d1 = f64_div(d1, u);
+                d2 = f64_div(d2, u);
+                x1 = f64_mul(x1, u);
             }
-            flag = ZERO;
-            d1 = f64_div(d1, u);
-            d2 = f64_div(d2, u);
-            x1 = f64_mul(x1, u);
         } else {
-            if (f64_lt(q2, ZERO)) {
+            if (f64_lt(q2, ZERO)) {      // singular -> zero result
                 flag = NEGONE;
                 d1 = ZERO; d2 = ZERO; x1 = ZERO;
                 h11 = ZERO; h21 = ZERO; h12 = ZERO; h22 = ZERO;
-                goto store;
+            } else {
+                flag = ONE;
+                h11 = f64_div(p1, p2);
+                h22 = f64_div(x1, y1);
+                float64_t u = f64_add(ONE, f64_mul(h11, h22));
+                float64_t tmp = f64_div(d2, u);
+                d2 = f64_div(d1, u);
+                d1 = tmp;
+                x1 = f64_mul(y1, u);
             }
-            flag = ONE;
-            h11 = f64_div(p1, p2);
-            h22 = f64_div(x1, y1);
-            float64_t u = f64_add(ONE, f64_mul(h11, h22));
-            float64_t tmp = f64_div(d2, u);
-            d2 = f64_div(d1, u);
-            d1 = tmp;
-            x1 = f64_mul(y1, u);
         }
 
+        //  Rescale D1, D2 into [1/gamsq, gamsq]. A singular case above leaves
+        //  d1 = d2 = 0, for which these loops are no-ops.
         //  Rescale D1 into [1/gamsq, gamsq].
         while (f64_ne(d1, ZERO) && f64_le(d1, rgamsq)) {
             if (f64_eq(flag, ZERO)) { flag = NEGONE; h11 = ONE; h22 = ONE; }
@@ -100,7 +102,6 @@ void drotmg(float64_t *D1, float64_t *D2, float64_t *X1, const float64_t y1, flo
         }
     }
 
-store:
     *D1 = d1;
     *D2 = d2;
     *X1 = x1;

--- a/src/blas/level1/hrotmg.c
+++ b/src/blas/level1/hrotmg.c
@@ -42,29 +42,31 @@ void hrotmg(float16_t *D1, float16_t *D2, float16_t *X1, const float16_t y1, flo
                 flag = NEGONE;
                 d1 = ZERO; d2 = ZERO; x1 = ZERO;
                 h11 = ZERO; h21 = ZERO; h12 = ZERO; h22 = ZERO;
-                goto store;
+            } else {
+                flag = ZERO;
+                d1 = f16_div(d1, u);
+                d2 = f16_div(d2, u);
+                x1 = f16_mul(x1, u);
             }
-            flag = ZERO;
-            d1 = f16_div(d1, u);
-            d2 = f16_div(d2, u);
-            x1 = f16_mul(x1, u);
         } else {
-            if (f16_lt(q2, ZERO)) {
+            if (f16_lt(q2, ZERO)) {      // singular -> zero result
                 flag = NEGONE;
                 d1 = ZERO; d2 = ZERO; x1 = ZERO;
                 h11 = ZERO; h21 = ZERO; h12 = ZERO; h22 = ZERO;
-                goto store;
+            } else {
+                flag = ONE;
+                h11 = f16_div(p1, p2);
+                h22 = f16_div(x1, y1);
+                float16_t u = f16_add(ONE, f16_mul(h11, h22));
+                float16_t tmp = f16_div(d2, u);
+                d2 = f16_div(d1, u);
+                d1 = tmp;
+                x1 = f16_mul(y1, u);
             }
-            flag = ONE;
-            h11 = f16_div(p1, p2);
-            h22 = f16_div(x1, y1);
-            float16_t u = f16_add(ONE, f16_mul(h11, h22));
-            float16_t tmp = f16_div(d2, u);
-            d2 = f16_div(d1, u);
-            d1 = tmp;
-            x1 = f16_mul(y1, u);
         }
 
+        //  Rescale D1, D2 into [1/gamsq, gamsq]. A singular case above leaves
+        //  d1 = d2 = 0, for which these loops are no-ops.
         //  Rescale D1 into [1/gamsq, gamsq].
         while (f16_ne(d1, ZERO) && f16_le(d1, rgamsq)) {
             if (f16_eq(flag, ZERO)) { flag = NEGONE; h11 = ONE; h22 = ONE; }
@@ -100,7 +102,6 @@ void hrotmg(float16_t *D1, float16_t *D2, float16_t *X1, const float16_t y1, flo
         }
     }
 
-store:
     *D1 = d1;
     *D2 = d2;
     *X1 = x1;

--- a/src/blas/level1/srotmg.c
+++ b/src/blas/level1/srotmg.c
@@ -42,29 +42,31 @@ void srotmg(float32_t *D1, float32_t *D2, float32_t *X1, const float32_t y1, flo
                 flag = NEGONE;
                 d1 = ZERO; d2 = ZERO; x1 = ZERO;
                 h11 = ZERO; h21 = ZERO; h12 = ZERO; h22 = ZERO;
-                goto store;
+            } else {
+                flag = ZERO;
+                d1 = f32_div(d1, u);
+                d2 = f32_div(d2, u);
+                x1 = f32_mul(x1, u);
             }
-            flag = ZERO;
-            d1 = f32_div(d1, u);
-            d2 = f32_div(d2, u);
-            x1 = f32_mul(x1, u);
         } else {
-            if (f32_lt(q2, ZERO)) {
+            if (f32_lt(q2, ZERO)) {      // singular -> zero result
                 flag = NEGONE;
                 d1 = ZERO; d2 = ZERO; x1 = ZERO;
                 h11 = ZERO; h21 = ZERO; h12 = ZERO; h22 = ZERO;
-                goto store;
+            } else {
+                flag = ONE;
+                h11 = f32_div(p1, p2);
+                h22 = f32_div(x1, y1);
+                float32_t u = f32_add(ONE, f32_mul(h11, h22));
+                float32_t tmp = f32_div(d2, u);
+                d2 = f32_div(d1, u);
+                d1 = tmp;
+                x1 = f32_mul(y1, u);
             }
-            flag = ONE;
-            h11 = f32_div(p1, p2);
-            h22 = f32_div(x1, y1);
-            float32_t u = f32_add(ONE, f32_mul(h11, h22));
-            float32_t tmp = f32_div(d2, u);
-            d2 = f32_div(d1, u);
-            d1 = tmp;
-            x1 = f32_mul(y1, u);
         }
 
+        //  Rescale D1, D2 into [1/gamsq, gamsq]. A singular case above leaves
+        //  d1 = d2 = 0, for which these loops are no-ops.
         //  Rescale D1 into [1/gamsq, gamsq].
         while (f32_ne(d1, ZERO) && f32_le(d1, rgamsq)) {
             if (f32_eq(flag, ZERO)) { flag = NEGONE; h11 = ONE; h22 = ONE; }
@@ -100,7 +102,6 @@ void srotmg(float32_t *D1, float32_t *D2, float32_t *X1, const float32_t y1, flo
         }
     }
 
-store:
     *D1 = d1;
     *D2 = d2;
     *X1 = x1;

--- a/tests/blas/include/test.h
+++ b/tests/blas/include/test.h
@@ -472,4 +472,6 @@ MunitResult test_srotmg_basic(const MunitParameter params[], void* u);
 MunitResult test_srotmg_flag_neg2(const MunitParameter params[], void* u);
 MunitResult test_drotmg_basic(const MunitParameter params[], void* u);
 
+MunitResult test_srotmg_singular(const MunitParameter params[], void* u);
+
 #endif // TEST_H

--- a/tests/blas/level1/test_rotmg.c
+++ b/tests/blas/level1/test_rotmg.c
@@ -35,3 +35,18 @@ MunitResult test_drotmg_basic(const MunitParameter params[], void* u) {
     assert_ullong(P[0].v, ==, 0x3ff0000000000000ull);  // flag = 1
     return MUNIT_OK;
 }
+
+//  Singular case (q2 < 0): zeroes the result and sets flag = -1. This is the
+//  path that previously used `goto store`; it must still produce all zeros.
+MunitResult test_srotmg_singular(const MunitParameter params[], void* u) {
+    float32_t d1 = { 0x3f800000 }, d2 = { 0xbf800000 }, x1 = { 0x3f800000 };  // 1, -1, 1
+    const float32_t y1 = { 0x3f800000 };
+    float32_t P[5] = {{0},{0},{0},{0},{0}};
+    srotmg(&d1, &d2, &x1, y1, P, 'n');
+    assert_ulong(P[0].v, ==, 0xbf800000u);  // flag = -1
+    assert_ulong(d1.v, ==, 0x00000000u);
+    assert_ulong(d2.v, ==, 0x00000000u);
+    assert_ulong(x1.v, ==, 0x00000000u);
+    for (int i = 1; i <= 4; i++) assert_ulong(P[i].v, ==, 0x00000000u);
+    return MUNIT_OK;
+}

--- a/tests/test_all.c
+++ b/tests/test_all.c
@@ -60,6 +60,7 @@ int main(int argc, char* argv[MUNIT_ARRAY_PARAM(argc + 1)]) {
             {"/test_srotmg_basic", test_srotmg_basic, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
             {"/test_srotmg_flag_neg2", test_srotmg_flag_neg2, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
             {"/test_drotmg_basic", test_drotmg_basic, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
+            {"/test_srotmg_singular", test_srotmg_singular, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
             
             {"/test_dasum_0", test_dasum_0, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
             {"/test_dasum_12345", test_dasum_12345, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},


### PR DESCRIPTION
`rotmg` used `goto store` to jump out of the two singular cases (`u <= 0` and `q2 < 0`) to the final store block, skipping the rescaling loops.

Replaced each with a plain `if/else`: the non-singular work moves into the `else`, and the rescaling loops that follow are already no-ops once a singular case has zeroed `d1`/`d2` — so no jump is needed. Drops both gotos and the `store:` label from `srotmg`/`drotmg`/`hrotmg`.

Behavior unchanged. Added `test_srotmg_singular` (`q2 < 0 → all zeros, flag = -1`) to cover the refactored path the goto previously guarded. **181/181.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)